### PR TITLE
Fix for mass-scan is not triggered by scan_interval

### DIFF
--- a/moneriote/rpc.py
+++ b/moneriote/rpc.py
@@ -94,6 +94,9 @@ class RpcNodeList:
         nodes = RpcNodeList()
         for node in blob:
             dt = dateutil_parse(node['dt'])
+            if (datetime.now() - dt).total_seconds() > CONFIG['scan_interval']:
+                nodes = RpcNodeList()
+                break
             if (datetime.now() - dt).total_seconds() < CONFIG['scan_interval'] and 'address' in node:
                 nodes.append(RpcNode(**node))
 

--- a/moneriote/rpc.py
+++ b/moneriote/rpc.py
@@ -62,7 +62,7 @@ class RpcNodeList:
             if node.valid:
                 data.append({'address': node.address,
                              'port': node.port,
-                             'dt': now.strftime('%Y-%m-%d %H:%M:%S')})
+                             'dt': node.dt})
         try:
             f = open(PATH_CACHE, 'w')
             f.write(json.dumps(data, indent=4))
@@ -93,7 +93,7 @@ class RpcNodeList:
 
         nodes = RpcNodeList()
         for node in blob:
-            dt = dateutil_parse(node.pop('dt'))
+            dt = dateutil_parse(node['dt'])
             if (datetime.now() - dt).total_seconds() < CONFIG['scan_interval'] and 'address' in node:
                 nodes.append(RpcNode(**node))
 
@@ -102,7 +102,7 @@ class RpcNodeList:
 
 
 class RpcNode:
-    def __init__(self, address: str, uid=None, port=18089, **kwargs):
+    def __init__(self, address: str, uid=None, port=18089, dt= '', **kwargs):
         """
         :param address: ip
         :param uid: record uid as per DNS provider
@@ -112,13 +112,18 @@ class RpcNode:
         self.uid = uid
         self._acceptableBlockOffset = 3
         self.valid = False
+        self.dt = dt
         self.kwargs = kwargs
 
     @staticmethod
     def is_valid(current_blockheight, obj):
+        now = datetime.now()
         # Scans the current node to see if the RPC port is available and is within the accepted range
         url = 'http://%s:%d/' % (obj.address, obj.port)
         url = '%s%s' % (url, 'getheight')
+
+        if len(obj.dt) == 0:
+            obj.dt = now.strftime('%Y-%m-%d %H:%M:%S')
 
         try:
             blob = make_json_request(url, verbose=False, timeout=2)


### PR DESCRIPTION
the `scan_interval ` does not work well. For days of testing, this fuction keeps popping nodes . In the end there are only 3-5 nodes stay in nodes cache. But the mass-scan was never triggered in days even the interval setting is an hour.
https://github.com/monero-ecosystem/moneriote-python/blob/a29c88a69603ec79d6763aaf80ec9933e7f1ef88/moneriote/rpc.py#L96-L98

So I removed `pop` in `chache_read` and keep thier time-stamp at scanning. Finally add one more condition to force it trigger mass-scan by return 0 node when node is older than `scan_interval`.
https://github.com/monero-ecosystem/moneriote-python/blob/010be541b4d091013f9cfe03ce4bba3d02770584/moneriote/rpc.py#L96-L99

@skftn It works good now with these workaround. But just like previous PR, I don't know if they are good stratgey in current architecture. So I put here for review when you have free time.